### PR TITLE
TitleCase package name, icesStocks data usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: msy
 Type: Package
-Title: Estimation of equilibrium reference points for fisheries
+Title: Estimation of Equilibrium Reference Points for Fisheries
 Version: 0.1.19
 Date: 2019-03-20
 Authors@R: c(

--- a/R/data.R
+++ b/R/data.R
@@ -2,7 +2,7 @@
 #' @title icesStocks
 #' @description A list FLStock object for various stocks
 #' @docType data
-#' @usage none
+#' @usage icesStocks
 #' @format a list
 #' @source NA
 #' @author NA

--- a/man/icesStocks.Rd
+++ b/man/icesStocks.Rd
@@ -9,7 +9,7 @@
 NA
 }
 \usage{
-none
+icesStocks
 }
 \description{
 A list FLStock object for various stocks


### PR DESCRIPTION
Hi, this pull request gets rid of a note (package name) and a warning (icesStocks usage).